### PR TITLE
Add Markdown plugin for footnotes

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "liquidjs": "^9.23.4",
     "markdown-it": "^12.0.6",
     "markdown-it-anchor": "^7.1.0",
+    "markdown-it-footnote": "^3.0.3",
     "markdown-it-github-preamble": "^1.0.0",
     "markdown-it-textual-uml": "^0.1.6",
     "markdown-it-toc-done-right": "git://github.com/nagaozen/markdown-it-toc-done-right.git#master",

--- a/src/renderer/markdown-renderer.ts
+++ b/src/renderer/markdown-renderer.ts
@@ -1,10 +1,11 @@
-import FileRenderer from './file-renderer';
-import * as MarkdownIt from 'markdown-it';
 import {getLanguage, highlight} from 'highlight.js';
-import * as tocPlugin from 'markdown-it-toc-done-right';
+import * as MarkdownIt from 'markdown-it';
 import * as anchorPlugin from 'markdown-it-anchor';
+import * as footnotePlugin from 'markdown-it-footnote';
 import * as umlPlugin from 'markdown-it-textual-uml';
+import * as tocPlugin from 'markdown-it-toc-done-right';
 import {readFile} from '../utils/file-utils';
+import FileRenderer from './file-renderer';
 
 export class MarkdownRenderer implements FileRenderer {
 
@@ -21,11 +22,12 @@ export class MarkdownRenderer implements FileRenderer {
     this.markdown.use(anchorPlugin);
     this.markdown.use(tocPlugin, {level: 2});
     this.markdown.use(umlPlugin);
+    this.markdown.use(footnotePlugin);
   }
 
   private highlight(str: string, lang: string) {
     let code = '';
-    
+
     if (lang && getLanguage(lang)) {
       code = highlight(lang, str, true).value;
     } else {

--- a/yarn.lock
+++ b/yarn.lock
@@ -331,6 +331,11 @@ markdown-it-anchor@^7.1.0:
   resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-7.1.0.tgz#30fb21497bf59e83ff4d1ddc052d821962e2489e"
   integrity sha512-loQggrwsIkkP7TOrESvmYkV2ikbQNNKhHcWyqC7/C2CmfHl1tkUizJJU8C5aGgg7J6oXVQJx17gk7i47tNn/lQ==
 
+markdown-it-footnote@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/markdown-it-footnote/-/markdown-it-footnote-3.0.3.tgz#e0e4c0d67390a4c5f0c75f73be605c7c190ca4d8"
+  integrity sha512-YZMSuCGVZAjzKMn+xqIco9d1cLGxbELHZ9do/TSYVzraooV8ypsppKNmUJ0fVH5ljkCInQAtFpm8Rb3eXSrt5w==
+
 markdown-it-github-preamble@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/markdown-it-github-preamble/-/markdown-it-github-preamble-1.0.0.tgz#0bc25b68ab2b5327854ce3149de2990de686ad86"


### PR DESCRIPTION
Adds [markdown-it-footnote](https://github.com/markdown-it/markdown-it-footnote) as a plugin for footnotes.

This will allow you to use `[^foo]` to create a footnote-reference and `[^foo]:` to create the actual footnote.

For instance:

```markdown
Docmaker[^docmaker], is a cool documentation rendering tool based on Markdown and HTML/CSS.

[^docmaker]: https://github.com/BlameButton/docmaker
``` 

will turn into:

```html
<p>Docmaker<sup class="footnote-ref"><a href="#fn1" id="fnref1">[1]</a></sup> is a cool documentation rendering tool based on Markdown and HTML/CSS.</p>

<ol class="footnotes-list">
  <li id="fn1" class="footnote-item">
    <p href="https://github.com/BlameButton/docmaker">
      <a>https://github.com/BlameButton/docmaker</a><a href="#fnref1" class="footnote-backref">↩︎</a>
    </p>
  </li>
</ol>
```
which is then rendered as:

> Docmaker<sup>[1]</sup> is a cool documentation rendering tool based on Markdown and HTML/CSS.
>
> 1. https://github.com/BlameButton/docmaker ↩︎